### PR TITLE
Add only-path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ or
 
 ```bash
 php artisan route:pretty --except-path=horizon --method=POST --reverse
+php artisan route:pretty --only-path=app --method=POST --reverse
 ```
 
 ## Changelog

--- a/src/Commands/PrettyRoutesCommand.php
+++ b/src/Commands/PrettyRoutesCommand.php
@@ -11,9 +11,10 @@ use Symfony\Component\Console\Terminal;
 
 class PrettyRoutesCommand extends Command
 {
-    public $signature = 'route:pretty 
+    public $signature = 'route:pretty
     {--sort=uri}
     {--except-path=}
+    {--only-path=}
     {--method=}
     {--reverse}
     ';
@@ -136,9 +137,18 @@ class PrettyRoutesCommand extends Command
         if ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
             return;
         }
+
         if ($this->option('except-path')) {
             foreach (explode(',', $this->option('except-path')) as $path) {
                 if (Str::contains($route['uri'], $path)) {
+                    return;
+                }
+            }
+        }
+
+        if ($this->option('only-path')) {
+            foreach (explode(',', $this->option('only-path')) as $path) {
+                if (! Str::contains($route['uri'], $path)) {
                     return;
                 }
             }


### PR DESCRIPTION
I don't know if this is the right name, but I've been talking for a while about wanting essentially a "grep" for the `route:list` command. I still want to add it one day to the core, but this seems an easy way to get it now!

![image](https://user-images.githubusercontent.com/151829/116490896-8cf61480-a866-11eb-9ce7-0f58139055ba.png)