### PR TITLE
Only call flush middleware group method if available

### DIFF
--- a/src/Commands/PrettyRoutesCommand.php
+++ b/src/Commands/PrettyRoutesCommand.php
@@ -60,7 +60,9 @@ class PrettyRoutesCommand extends Command
      */
     public function handle()
     {
-        $this->router->flushMiddlewareGroups();
+        if (method_exists($this->router, 'flushMiddlewareGroups')) {
+            $this->router->flushMiddlewareGroups();
+        }
 
         if (empty($this->router->getRoutes())) {
             return $this->error("Your application doesn't have any routes.");


### PR DESCRIPTION
As discussed in #4, the `flushMiddlewareGroups()` method is not available before Laravel 8.28.0.

There are three possible fixes:

- Require Laravel 8.28.0
- Make the call optional, as I've done in this PR
- Find a way to reproduce what the call is doing manually if it doesn't exist

I'll let you decide which you'd prefer!