### PR TITLE
Docs: Add composer require --dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ You can install the package via composer:
 composer require wulfheart/pretty_routes
 ```
 
+If you want to install this package on dev environment only run:
+
+```bash
+composer require --dev wulfheart/pretty_routes
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
Update docs to include composer command to require the package on dev environment only